### PR TITLE
Undefined name: zero_init_residual

### DIFF
--- a/mmfashion/models/backbones/resnet.py
+++ b/mmfashion/models/backbones/resnet.py
@@ -179,6 +179,7 @@ class ResNet(nn.Module):
             layers[3],
             stride=2,
             dilate=replace_stride_with_dilation[2])
+        self.zero_init_residual = zero_init_residual
 
     def init_weights(self, pretrained=None):
         print('pretrained model', pretrained)
@@ -197,7 +198,7 @@ class ResNet(nn.Module):
             # Zero-initialize the last BN in each residual branch,
             # so that the residual branch starts with zeros, and each residual block behaves like an identity.
             # This improves the model by 0.2~0.3% according to https://arxiv.org/abs/1706.02677
-            if zero_init_residual:
+            if self.zero_init_residual:
                 for m in self.modules():
                     if isinstance(m, Bottleneck):
                         nn.init.constant_(m.bn3.weight, 0)


### PR DESCRIPTION
`zero_init_residual` is an _undefined name_ in this context which has the potential to raise NameError at runtime.

[flake8](http://flake8.pycqa.org) testing of https://github.com/open-mmlab/mmfashion on Python 3.8.0

https://travis-ci.com/cclauss/mmfashion/builds/146564049

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./mmfashion/datasets/utils.py:23:27: F821 undefined name 'np'
    elif isinstance(data, np.ndarray):
                          ^
./mmfashion/datasets/utils.py:25:27: F821 undefined name 'Sequence'
    elif isinstance(data, Sequence) and not mmcv.is_str(data):
                          ^
./mmfashion/datasets/utils.py:25:45: F821 undefined name 'mmcv'
    elif isinstance(data, Sequence) and not mmcv.is_str(data):
                                            ^
./mmfashion/core/evaluation/landmark_detect_eval.py:52:30: F821 undefined name 'norm'
                norm_error = norm(gt_lm_arr - pred_lm_arr)
                             ^
./mmfashion/core/evaluation/landmark_detect_eval.py:56:24: F821 undefined name 'norm'
                dist = norm(pred_lm - gt_lm)
                       ^
./mmfashion/apis/test_landmark_detector.py:34:9: F821 undefined name '_dist_test'
        _dist_test(model, dataset, cfg, validate=validate)
        ^
./mmfashion/apis/test_predictor.py:34:9: F821 undefined name '_dist_test'
        _dist_test(model, dataset, cfg, validate=validate)
        ^
./mmfashion/models/builder.py:32:31: F821 undefined name 'module'
        return nn.Sequential(*module)
                              ^
./mmfashion/models/backbones/resnet.py:200:16: F821 undefined name 'zero_init_residual'
            if zero_init_residual:
               ^
./mmfashion/models/predictor/global_predictor.py:70:15: F821 undefined name 'RoIPredictor'
        super(RoIPredictor, self).init_weights(pretrained)
              ^
./mmfashion/models/predictor/roi_predictor.py:55:21: F821 undefined name 'landmarks'
        landmarks = landmarks.unsqueeze(0)
                    ^
./tools/train_predictor.py:63:9: F821 undefined name 'set_random_seed'
        set_random_seed(args.seed)
        ^
./tools/train_retriever.py:63:9: F821 undefined name 'set_random_seed'
        set_random_seed(args.seed)
        ^
./tools/train_landmark_detector.py:64:9: F821 undefined name 'set_random_seed'
        set_random_seed(args.seed)
        ^
14    F821 undefined name '_dist_test'
14
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.